### PR TITLE
Fix NodePort selector bug and postgres.database typo

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -22,6 +22,9 @@ jobs:
           - name: immich-folders
             context: ./containers/immich-folders
             dockerfile: ./containers/immich-folders/Dockerfile
+          - name: sunshine-desktop
+            context: ./containers/sunshine-desktop
+            dockerfile: ./containers/sunshine-desktop/Dockerfile
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ To uninstall the chart:
 helm delete my-<chart-name>
 ```
 
-![Helm Unit Tests](https://github.com/spartan-dou/helm-charts/actions/workflows/helm-tests.yaml/badge.svg)
+![Helm Unit Tests](https://github.com/spartan-dou/helm-charts/actions/workflows/helm-tests.yml/badge.svg)

--- a/charts/commons/templates/helpers/_addons.tpl
+++ b/charts/commons/templates/helpers/_addons.tpl
@@ -206,7 +206,7 @@
       "containers" (list (dict
         "image" (dict
             "repository" .Values.addons.redis.image.repository
-            "tag" .Values.addons.redis.image.tag | default "latest"
+            "tag" (default "latest" .Values.addons.redis.image.tag)
         )
         "livenessProbe" (dict
           "tcpSocket" (dict "port" .Values.addons.redis.port)

--- a/charts/commons/templates/helpers/_commons.tpl
+++ b/charts/commons/templates/helpers/_commons.tpl
@@ -153,7 +153,7 @@ app: {{ .Release.Name }}
 */}}
 {{- define "postgres.database" -}}
 {{- if .Values.addons.postgres.enabled -}}
-{{- include "commons.getValue" (dict "Values" $.Values "Chart" $.Chart "Release" $.Release "component" $.Values.addons.postgres "value" "__addons__postgres__databasse") }}
+{{- include "commons.getValue" (dict "Values" $.Values "Chart" $.Chart "Release" $.Release "component" $.Values.addons.postgres "value" "__addons__postgres__database") }}
 {{- end }}
 {{- end }}
 
@@ -166,6 +166,7 @@ app: {{ .Release.Name }}
 {{- end -}}
 {{- end }}
 
+{{/*
   Fonction pour recuépérer le host postgres global
 */}}
 {{- define "postgres.host" -}}

--- a/charts/commons/templates/service.yaml
+++ b/charts/commons/templates/service.yaml
@@ -15,6 +15,7 @@ metadata:
 spec:
   type: {{ default "ClusterIP" .type }}
   ports:
+    {{- $type := default "ClusterIP" .type }}
     {{- range .ports }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -22,7 +23,7 @@ spec:
       {{- with .protocol }}
       protocol: {{ . }}
       {{- end }}
-      {{- if eq $.type "NodePort" }}
+      {{- if eq $type "NodePort" }}
       {{- with .nodePort }}
       nodePort: {{ . }}
       {{- end }}


### PR DESCRIPTION
- service.yaml: nodePort was gated on $.type (root context, always
  empty) instead of the service's own type, so explicit nodePort
  values were silently dropped for NodePort services.
- _commons.tpl: fix "databasse" typo breaking the postgres.database
  helper, and restore the missing {{/* on the postgres.host comment
  block.
- _addons.tpl: fix default "latest" precedence on the redis image tag
  (was applied to the whole image dict instead of the tag field).
- docker-build.yml: add sunshine-desktop to the build matrix, it was
  never actually built/published despite being actively maintained.
- README.md: fix badge URL (helm-tests.yaml -> helm-tests.yml).