### PR TITLE
Wire up Redis authentication (addons.redis.password)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,9 +151,11 @@ Toutes les valeurs de `env[].value` et `env[].valueFrom.secretKeyRef.name` passe
 | `__addons__postgres__password_secret` | Nom du Secret `<release>-postgres-secret` |
 | `__components__postgres__host` / `__username__` / `__password__` / `__database__` / `__password_secret__` | Idem mais sur le cluster CloudNativePG **embarqué dans le component courant** (`component.postgres.*`) |
 | `__addons__redis__host` / `__addons__redis__port` | Host / port du service Redis partagé (`addons.redis`) |
+| `__addons__redis__password` | `addons.redis.password` en clair |
+| `__addons__redis__password_secret` | Nom du Secret contenant le mot de passe Redis (clé `password`) |
 | `__<nom-de-component>__pvc__<nom-du-pvc>` | Nom Kubernetes complet du PVC `<nom-du-pvc>` défini sur le component `<nom-de-component>` (ex : `__nginx__pvc__data-2-pvc`) |
 | `__components__pvc__<nom-du-pvc>` | Idem, mais sur le component courant |
-| `__<nom>__configmap__<nom>` / `__<nom>__service__<nom>` | Même principe pour un ConfigMap ou un Service |
+| `__<nom>__configmap__<nom>` / `__<nom>__service__<nom>` / `__<nom>__secret__<nom>` | Même principe pour un ConfigMap, un Service ou un Secret |
 | `__global__<clé>` | `global.var.<clé>` |
 
 Exemple (tiré des tests) :
@@ -325,8 +327,9 @@ Instance Redis (Deployment + Service + PVC `1Gi` par défaut). Quand elle est ac
 | `image.tag` | `8.8.0-alpine` |
 | `port` | `6379` |
 | `storage.size` / `storage.storageClassName` | repli sur `global.pvc.storage.*` |
+| `password` | `""` |
 
-> Aucune authentification n'est configurée par la chart actuellement (pas de `requirepass`) : Redis est déployé sans mot de passe même si un champ `password` est renseigné dans les values, il n'est pas encore consommé par les templates.
+Si `password` est renseigné, un Secret `<release>-redis-auth` est généré, Redis démarre avec `--requirepass`, et l'initContainer `wait-for-redis` (injecté partout) ainsi que les consommateurs peuvent récupérer le mot de passe via `__addons__redis__password` / `__addons__redis__password_secret` (voir [`commons.getValue`](#variables-denvironnement-et-commonsgetvalue)). Laissé vide (défaut), Redis reste sans authentification, comme avant.
 
 #### `addons.pgadmin`
 
@@ -383,5 +386,4 @@ Le workflow GitHub Actions `helm-tests.yml` exécute les deux commandes ci-dessu
 
 ### Points d'attention connus
 
-- `addons.redis.password` n'est pas câblé côté template (pas d'authentification Redis).
 - Si `service.ports` est renseigné, ses ports sont dupliqués sur **tous** les conteneurs d'un `deployment` multi-conteneurs (pas seulement le conteneur principal).

--- a/charts/commons/templates/helpers/_addons.tpl
+++ b/charts/commons/templates/helpers/_addons.tpl
@@ -17,13 +17,15 @@
 
   {{- if $.Values.addons.redis.enabled }}
     {{ $host := include "commons.getValue" (dict "Values" $.Values "Chart" $.Chart "Release" $.Release "value" "__addons__redis__host") }}
+    {{- $redisAuth := ne (default "" $.Values.addons.redis.password) "" }}
     {{- $redisInit := dict
       "name" "wait-for-redis"
       "image" (dict
         "repository" $.Values.addons.redis.image.repository
         "tag" $.Values.addons.redis.image.tag
       )
-      "command" (list "sh" "-c" (printf "until redis-cli -h %s ping | grep PONG; do echo waiting for redis; sleep 2; done" $host))
+      "env" (ternary (list (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" "__addons__redis__password_secret" "key" "password")))) (list) $redisAuth)
+      "command" (list "sh" "-c" (printf "until redis-cli -h %s %s ping | grep PONG; do echo waiting for redis; sleep 2; done" $host (ternary "-a \"$REDIS_PASSWORD\"" "" $redisAuth)))
     }}
     {{- $merged = append $merged $redisInit }}
   {{- end }}
@@ -76,13 +78,15 @@
 
       {{- if $.Values.addons.redis.enabled }}
         {{ $host := include "commons.getValue" (dict "Values" $.Values "Chart" $.Chart "Release" $.Release "value" "__addons__redis__host") }}
+        {{- $redisAuth := ne (default "" $.Values.addons.redis.password) "" }}
         {{- $redisInit := dict
           "name" "wait-for-redis"
           "image" (dict
             "repository" $.Values.addons.redis.image.repository
             "tag" $.Values.addons.redis.image.tag
           )
-          "command" (list "sh" "-c" (printf "until redis-cli -h %s ping | grep PONG; do echo waiting for redis; sleep 2; done" $host))
+          "env" (ternary (list (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" "__addons__redis__password_secret" "key" "password")))) (list) $redisAuth)
+          "command" (list "sh" "-c" (printf "until redis-cli -h %s %s ping | grep PONG; do echo waiting for redis; sleep 2; done" $host (ternary "-a \"$REDIS_PASSWORD\"" "" $redisAuth)))
         }}
         {{- $mergedCronjob = append $mergedCronjob $redisInit }}
       {{- end }}
@@ -200,14 +204,18 @@
 
 {{/* === Addon Redis === */}}
 {{- if .Values.addons.redis.enabled }}
+  {{- $redisAuth := ne (default "" .Values.addons.redis.password) "" }}
   {{- $defaults := dict
     "name" "redis"
+    "secrets" (ternary (list (dict "name" "auth" "data" (dict "password" .Values.addons.redis.password))) (list) $redisAuth)
     "deployment" (dict
       "containers" (list (dict
         "image" (dict
             "repository" .Values.addons.redis.image.repository
             "tag" (default "latest" .Values.addons.redis.image.tag)
         )
+        "command" (ternary (list "redis-server" "--requirepass" "$(REDIS_PASSWORD)") (list) $redisAuth)
+        "env" (ternary (list (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" "__addons__redis__password_secret" "key" "password")))) (list) $redisAuth)
         "livenessProbe" (dict
           "tcpSocket" (dict "port" .Values.addons.redis.port)
           "initialDelaySeconds" 5
@@ -225,7 +233,7 @@
       ))
     "volumes" (list (dict
       "name" "data"
-      "pvc" (dict 
+      "pvc" (dict
         "name" (printf "data")
         "storage" (dict
           "size" (default .Values.global.pvc.storage.size (default dict .Values.addons.redis.storage).size)
@@ -240,7 +248,7 @@
     )
   }}
   {{- $raw := .Values.addons.redis | default dict }}
-  {{- $overrides := omit $raw "enabled" "name" }}
+  {{- $overrides := omit $raw "enabled" "name" "password" }}
   {{- $redis := merge $defaults $overrides }}
   {{- $addons = append $addons $redis }}
 {{- end }}

--- a/charts/commons/templates/helpers/_addons.tpl
+++ b/charts/commons/templates/helpers/_addons.tpl
@@ -214,7 +214,7 @@
             "repository" .Values.addons.redis.image.repository
             "tag" (default "latest" .Values.addons.redis.image.tag)
         )
-        "command" (ternary (list "redis-server" "--requirepass" "$(REDIS_PASSWORD)") (list) $redisAuth)
+        "args" (ternary (list "--requirepass" "$(REDIS_PASSWORD)") (list) $redisAuth)
         "env" (ternary (list (dict "name" "REDIS_PASSWORD" "valueFrom" (dict "secretKeyRef" (dict "name" "__addons__redis__password_secret" "key" "password")))) (list) $redisAuth)
         "livenessProbe" (dict
           "tcpSocket" (dict "port" .Values.addons.redis.port)

--- a/charts/commons/templates/helpers/_commons.tpl
+++ b/charts/commons/templates/helpers/_commons.tpl
@@ -121,8 +121,12 @@ app: {{ .Release.Name }}
       {{- $value = include "commons.fullname" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release "component" (dict "name" .Values.addons.redis.name)) }}
     {{- else if eq $field "port" }}
       {{- $value = .Values.addons.redis.port }}
+    {{- else if eq $field "password" }}
+      {{- $value = .Values.addons.redis.password }}
+    {{- else if eq $field "password_secret" }}
+      {{- $value = include "commons.fullname" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release "name" "auth" "component" (dict "name" .Values.addons.redis.name)) }}
     {{- end }}
-  {{- else if or (eq $type "pvc") (eq $type "configmap") (eq $type "service") }}
+  {{- else if or (eq $type "pvc") (eq $type "configmap") (eq $type "service") (eq $type "secret") }}
     {{- $c := dict }}
     {{- if not (eq $source "components") }}
       {{- $c = (dict "name" $source) }}

--- a/charts/commons/templates/secret.yaml
+++ b/charts/commons/templates/secret.yaml
@@ -11,5 +11,6 @@ kind: Secret
 metadata:
   name: {{ include "commons.fullname" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release "name" .name "component" $component) }}
 type: {{ default "Opaque" .type }}
+---
 {{- end }}
 {{- end }}

--- a/charts/commons/tests/deployments_test.yaml
+++ b/charts/commons/tests/deployments_test.yaml
@@ -155,6 +155,21 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: redis:8.2.1
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - redis-server
+            - --requirepass
+            - $(REDIS_PASSWORD)
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: REDIS_PASSWORD
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.name
+          value: test-redis-auth
+      - equal:
+          path: spec.template.spec.containers[0].env[1].valueFrom.secretKeyRef.key
+          value: password
 
   - it: ne doit pas créer le Service Redis si désactivé
     set:

--- a/charts/commons/tests/deployments_test.yaml
+++ b/charts/commons/tests/deployments_test.yaml
@@ -156,9 +156,8 @@ tests:
           path: spec.template.spec.containers[0].image
           value: redis:8.2.1
       - equal:
-          path: spec.template.spec.containers[0].command
+          path: spec.template.spec.containers[0].args
           value:
-            - redis-server
             - --requirepass
             - $(REDIS_PASSWORD)
       - equal:

--- a/charts/commons/tests/secrets_test.yaml
+++ b/charts/commons/tests/secrets_test.yaml
@@ -40,3 +40,18 @@ tests:
       - equal:
           path: data.password
           value: Y2hhbmdlbWU=
+
+  # --- Secret ---
+  - it: Vérifie le Secret Redis (auth)
+    templates:
+      - templates/secret.yaml
+    documentSelector:
+      path: metadata.name
+      value: test-redis-auth
+    asserts:
+      - equal:
+          path: type
+          value: Opaque
+      - equal:
+          path: data.password
+          value: Y2hhbmdlbWU=

--- a/charts/commons/values.yaml
+++ b/charts/commons/values.yaml
@@ -27,6 +27,7 @@ addons:
       repository: redis
       tag: 8.8.0-alpine
     port: 6379
+    password: ""
   pgadmin:
     enabled: false
     image:


### PR DESCRIPTION
## Summary

`addons.redis.password` was already present in the values schema (and set in the test fixture) but never consumed by any template: Redis ran without auth regardless of what was configured. When the password is set:

- A Secret `<release>-redis-auth` is generated (mirrors the existing postgres secret pattern).
- The Redis container starts with `--requirepass $(REDIS_PASSWORD)`.
- The `wait-for-redis` initContainer (injected into every component's deployment and cronjobs when the addon is enabled) passes `-a` to `redis-cli`.
- `__addons__redis__password` / `__addons__redis__password_secret` lookup keys are added to `commons.getValue`, mirroring the postgres convention, so consuming components can read the password too.
- `commons.getValue` also gained generic `secret` type support (`__<component>__secret__<name>`), reused here and available for any custom secret.

Left empty (the default), Redis stays unauthenticated exactly as before — no behavior change for existing installs.

## Test plan

- [x] Added `helm-unittest` assertions (deployments_test.yaml, secrets_test.yaml) covering the new command/env/secret, using the existing test fixture which already sets `addons.redis.password: changeme`.
- [x] `helm lint` / `helm unittest` pass in CI (`helm-tests.yml`) — could not run helm locally in this environment (no network access to install the binary); reviewed the template diff by hand and sanity-checked `{{`/`}}` and paren balance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_