### PR TITLE
Add values.schema.json for the commons chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Charts Helm maison de `spartan-dou`, packagées et publiées via `chart-releaser
     - [`addons.pgadmin`](#addonspgadmin)
     - [`addons.postgres`](#addonspostgres)
   - [Nommage des ressources](#nommage-des-ressources)
+  - [Validation des values](#validation-des-values)
   - [Tests](#tests)
   - [Points d'attention connus](#points-dattention-connus)
 
@@ -363,6 +364,10 @@ Les noms de ressources sont générés par le helper `commons.fullname`, qui con
 | Ressource globale (pas de component) | `<release>` |
 | Ressources propres à un component (Deployment, Service, Ingress…) | `<release>-<component>` |
 | Sous-ressource nommée d'un component (PVC, ConfigMap…) | `<release>-<component>-<nom-de-la-sous-ressource>` |
+
+### Validation des values
+
+`charts/commons/values.schema.json` valide la structure de `values.yaml` (types, champs requis) à chaque `helm install`/`upgrade`/`template`/`lint`. En particulier, il impose les champs requis quand un addon ou le RBAC est activé (ex : `global.rbac.enabled: true` sans `serviceAccountName`/`clusterRoleName`, ou `addons.pgadmin.enabled: true` sans `auth.email`/`auth.password`, échouent la validation avant même le rendu des templates). Le contenu libre de `components[]` n'est volontairement pas contraint au-delà de `name` (requis), pour ne pas bloquer les usages non documentés.
 
 ### Tests
 

--- a/charts/commons/values.schema.json
+++ b/charts/commons/values.schema.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "commons",
+  "type": "object",
+  "required": ["global", "addons"],
+  "properties": {
+    "global": {
+      "type": "object",
+      "required": ["timezone", "pvc", "rbac"],
+      "properties": {
+        "timezone": { "type": "string", "minLength": 1 },
+        "securityContext": { "type": "object" },
+        "pvc": {
+          "type": "object",
+          "required": ["storage"],
+          "properties": {
+            "storage": {
+              "type": "object",
+              "properties": {
+                "size": { "type": "string" },
+                "storageClassName": { "type": "string" },
+                "accessMode": {
+                  "type": "string",
+                  "enum": ["ReadWriteOnce", "ReadOnlyMany", "ReadWriteMany", "ReadWriteOncePod"]
+                }
+              }
+            }
+          }
+        },
+        "ingress": {
+          "type": "object",
+          "properties": {
+            "className": { "type": "string" }
+          }
+        },
+        "rbac": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "serviceAccountName": { "type": "string" },
+            "clusterRoleName": { "type": "string" },
+            "rules": { "type": "array", "items": { "type": "object" } }
+          },
+          "if": {
+            "properties": { "enabled": { "const": true } }
+          },
+          "then": {
+            "required": ["serviceAccountName", "clusterRoleName"],
+            "properties": {
+              "serviceAccountName": { "type": "string", "minLength": 1 },
+              "clusterRoleName": { "type": "string", "minLength": 1 }
+            }
+          }
+        },
+        "var": { "type": "object" }
+      }
+    },
+    "components": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "addons": {
+      "type": "object",
+      "properties": {
+        "vscode": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "$ref": "#/definitions/image" },
+            "service": {
+              "type": "object",
+              "properties": { "port": { "type": "integer" } }
+            }
+          }
+        },
+        "redis": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "name": { "type": "string" },
+            "image": { "$ref": "#/definitions/image" },
+            "port": { "type": "integer" },
+            "password": { "type": "string" }
+          }
+        },
+        "pgadmin": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "$ref": "#/definitions/image" },
+            "auth": {
+              "type": "object",
+              "properties": {
+                "email": { "type": "string" },
+                "password": { "type": "string" }
+              }
+            }
+          },
+          "if": {
+            "properties": { "enabled": { "const": true } }
+          },
+          "then": {
+            "required": ["auth"],
+            "properties": {
+              "auth": {
+                "type": "object",
+                "required": ["email", "password"],
+                "properties": {
+                  "email": { "type": "string", "minLength": 1 },
+                  "password": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        },
+        "postgres": {
+          "type": "object",
+          "required": ["enabled"],
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "image": { "$ref": "#/definitions/image" },
+            "storage": {
+              "type": "object",
+              "properties": {
+                "size": { "type": "string" },
+                "storageClassName": { "type": "string" }
+              }
+            },
+            "cluster": {
+              "type": "object",
+              "properties": {
+                "username": { "type": "string" },
+                "password": { "type": "string" },
+                "database": { "type": "string" }
+              }
+            }
+          },
+          "if": {
+            "properties": { "enabled": { "const": true } }
+          },
+          "then": {
+            "required": ["cluster"],
+            "properties": {
+              "cluster": {
+                "type": "object",
+                "required": ["username", "password"],
+                "properties": {
+                  "username": { "type": "string", "minLength": 1 },
+                  "password": { "type": "string", "minLength": 1 }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "image": {
+      "type": "object",
+      "properties": {
+        "repository": { "type": "string", "minLength": 1 },
+        "tag": { "type": ["string", "number"] }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds `charts/commons/values.schema.json`, validated automatically by Helm on `install`/`upgrade`/`template`/`lint`. It catches common misconfigurations before any template even renders:

- `global.rbac.enabled: true` without `serviceAccountName`/`clusterRoleName`
- `addons.pgadmin.enabled: true` without `auth.email`/`auth.password`
- `addons.postgres.enabled: true` without `cluster.username`/`cluster.password`
- a `components[]` entry missing `name`

`components[]` stays deliberately unconstrained beyond requiring `name`, since its shape is very open-ended (arbitrary container/volume/probe specs) and over-constraining it risked rejecting legitimate, undocumented usage.

## Test plan

- [x] Could not run `helm lint` in this environment (no network to install the helm binary), so verified the schema directly with Python's `jsonschema` library instead:
  - `charts/commons/values.yaml` (chart defaults) validates cleanly.
  - The test fixture (`charts/commons/tests/values/values.yaml`) merged on top of the chart defaults — the same shape Helm itself would validate — validates cleanly.
  - Four targeted negative cases (RBAC/pgAdmin/postgres enabled without required fields, and a component without `name`) are all correctly rejected.
- [ ] Confirm `helm lint charts/commons` also passes in CI now that a `values.schema.json` is present.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_