### PR TITLE
Enrich Chart.yaml metadata and add .helmignore

### DIFF
--- a/charts/commons/.helmignore
+++ b/charts/commons/.helmignore
@@ -1,0 +1,25 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+# Chart tests (not part of the packaged chart)
+tests/

--- a/charts/commons/Chart.yaml
+++ b/charts/commons/Chart.yaml
@@ -1,4 +1,20 @@
 apiVersion: v2
 name: commons
-description: Commons chart
+description: Generic "à la carte" Helm chart to deploy one or several lightweight applications (Deployment/Service/Ingress/CronJob) from a single values file, with optional Redis, PostgreSQL (CloudNativePG), pgAdmin and code-server addons.
+type: application
 version: 0.7.16
+keywords:
+  - generic
+  - library
+  - postgres
+  - cloudnative-pg
+  - redis
+  - pgadmin
+  - vscode
+  - code-server
+home: https://github.com/spartan-dou/helm-charts
+sources:
+  - https://github.com/spartan-dou/helm-charts
+maintainers:
+  - name: spartan-dou
+    url: https://github.com/spartan-dou


### PR DESCRIPTION
## Summary

`Chart.yaml` only had `name`/`description`/`version`, so `helm search repo`, Artifact Hub, and any chart-index UI had nothing useful to show.

- Added a real `description`, `type: application`, `keywords`, `home`/`sources` links back to this repo, and a `maintainers` entry (`spartan-dou`, GitHub profile URL only — no email, to avoid publishing personal contact info).
- Added a standard `.helmignore` excluding VCS/editor cruft and the `tests/` fixtures from the packaged `.tgz`. `helm-tests.yml` still lints/unit-tests directly against the source directory, so it's unaffected.

## Test plan

- [x] Validated `Chart.yaml` parses as YAML.
- [ ] `helm lint` / `chart-releaser` package build still succeed in CI — could not run helm locally in this environment.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_