### PR TITLE
Fix sunshine-desktop Docker build: run apt-get as root

### DIFF
--- a/containers/sunshine-desktop/Dockerfile
+++ b/containers/sunshine-desktop/Dockerfile
@@ -1,5 +1,7 @@
 FROM lizardbyte/sunshine:v2026.426.150436-ubuntu-24.04
 
+USER root
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install Xorg, XFCE, audio, and basic tools


### PR DESCRIPTION
## Summary

Every "Build All Docker Images" run on `main` has been failing on the `sunshine-desktop` job since it was added to the build matrix, with:

```
#8 0.061 E: List directory /var/lib/apt/lists/partial is missing. - Acquire (13: Permission denied)
```

The `lizardbyte/sunshine` base image defaults to a non-root user, so `apt-get update`/`install` had no permission to write to `/var/lib/apt/lists`. Adding `USER root` right after `FROM` restores root for the package installation steps; the existing `USER sunshine` at the end of the file still drops privileges for the actual container runtime, so this only affects the build, not the running container.

`immich-folders` (the other image in the matrix) is unaffected — its `alpine` base image runs as root by default.

## Test plan

- [x] Diagnosed from the actual failing job logs (run `30076605976`, job `sunshine-desktop`): confirmed the exact `apt-get`/permission error and that it's the first `RUN` step after `FROM`.
- [ ] Confirm the next `Build All Docker Images` run on `main` builds and pushes `sunshine-desktop` successfully after this merges.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_