### PR TITLE
Only inject service.ports onto the first container of a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Charts Helm maison de `spartan-dou`, packagées et publiées via `chart-releaser
   - [Nommage des ressources](#nommage-des-ressources)
   - [Validation des values](#validation-des-values)
   - [Tests](#tests)
-  - [Points d'attention connus](#points-dattention-connus)
 
 ## Installation
 
@@ -136,7 +135,7 @@ Chaque entrée de `containers[]` :
 - `livenessProbe` / `readinessProbe` / `startupProbe` / `probe` — voir [Probes](#probes)
 - `resources`
 
-> Si `service.ports` est défini sur le component, ses ports sont automatiquement ajoutés à la section `ports` de **chaque** conteneur de la liste (en plus de `additionalsPorts`) — utile pour un conteneur unique, à garder en tête si plusieurs conteneurs cohabitent dans le même pod.
+> Si `service.ports` est défini sur le component, ses ports sont automatiquement ajoutés à la section `ports` du **premier** conteneur de la liste uniquement (en plus de ses éventuels `additionalsPorts`). Les autres conteneurs ne reçoivent que leurs propres `additionalsPorts`, s'ils en définissent.
 
 Une annotation `checksum/<nom-du-volume>` est automatiquement ajoutée au pod pour chaque volume de type `configMap` généré par la chart (pas les `useExisting`) contenant des `data`, afin de déclencher un rollout quand le contenu du ConfigMap change.
 
@@ -383,7 +382,3 @@ helm unittest charts/commons
 ```
 
 Le workflow GitHub Actions `helm-tests.yml` exécute les deux commandes ci-dessus sur chaque pull request touchant `charts/**`.
-
-### Points d'attention connus
-
-- Si `service.ports` est renseigné, ses ports sont dupliqués sur **tous** les conteneurs d'un `deployment` multi-conteneurs (pas seulement le conteneur principal).

--- a/charts/commons/templates/deployment.yaml
+++ b/charts/commons/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
       {{- end }}
       {{- with .containers }}
       containers:
-        {{- range . }}
+        {{- range $index, $_ := . }}
         - name: {{ default $component.name .name }}
           image: {{ .image.repository }}:{{ .image.tag | default "latest" }}
           {{- with .command }}
@@ -108,8 +108,9 @@ spec:
             {{- end }}
           {{- end }}
           
-          {{- if or .additionalsPorts  (and $component.service $component.service.ports) }}
+          {{- if or .additionalsPorts (and (eq $index 0) $component.service $component.service.ports) }}
           ports:
+            {{- if eq $index 0 }}
             {{- range $component.service.ports }}
             - name: {{ .name }}
               containerPort: {{ default .port .targetPort }}
@@ -117,6 +118,7 @@ spec:
               {{- with .hostPort }}
               hostPort: {{ . }}
               {{- end }}
+            {{- end }}
             {{- end }}
             {{- range .additionalsPorts }}
             - name: {{ .name }}

--- a/charts/commons/tests/deployments_test.yaml
+++ b/charts/commons/tests/deployments_test.yaml
@@ -187,3 +187,32 @@ tests:
     asserts:
       - hasDocuments:
           count: 3
+
+  - it: n'ajoute les ports du Service que sur le premier conteneur d'un deployment multi-conteneurs
+    set:
+      components:
+        - name: multi
+          deployment:
+            containers:
+              - image:
+                  repository: primary
+                  tag: latest
+              - image:
+                  repository: sidecar
+                  tag: latest
+          service:
+            ports:
+              - name: http
+                port: 8081
+    documentSelector:
+      path: metadata.name
+      value: test-multi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: http
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8081
+      - notExists:
+          path: spec.template.spec.containers[1].ports


### PR DESCRIPTION
## Summary

`deployment.yaml` was duplicating `$component.service.ports` onto **every** container in a multi-container `deployment.containers[]` list, instead of just the one whose port(s) actually match the Service. This was called out as a "known caveat" in the README.

Fixed by tracking the container's index in the range (`{{- range $index, $_ := . }}`) and only injecting `service.ports` when `$index == 0`. Each container's own `additionalsPorts` is untouched and still applies regardless of index.

**Why this is safe for already-deployed charts:**
- Single-container components — the norm, and the only case exercised by the deployment/cronjob/job test suites today — always have `$index == 0`, so the rendered manifest is byte-for-byte identical to before. No change at all for the common case.
- For multi-container components, the only change is that sidecar containers stop getting a redundant/misleading `ports:` block. Kubernetes' `ports` field is purely declarative (it doesn't control what a container actually binds), so no running container's real network behavior changes. The one edge case worth calling out: if `hostPort` was relied upon being reserved by *every* container in the pod, that container now needs its own explicit `additionalsPorts` entry — arguably that was already a latent bug (duplicate hostPort reservations across containers in one pod).

## Test plan

- [x] Added a dedicated `helm-unittest` case with a 2-container component (`deployments_test.yaml`) asserting the first container gets the Service's ports and the second does not.
- [x] The existing single-container ports test is untouched and exercises the same code path with `$index` always `0`.
- [x] Verified `{{`/`}}` balance in `deployment.yaml` and that the new test file is valid YAML.
- [ ] `helm lint` / `helm unittest` pass in CI (`helm-tests.yml`) — could not run helm locally in this environment (no network access to install the binary).

Also updates `README.md`: removes the now-resolved "known caveats" bullet and corrects the `deployment` section's description of this behavior.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_