### PR TITLE
Fix Renovate creating a new Dependency Dashboard issue every run

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -25,8 +25,12 @@ jobs:
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # Onboarding not needed for self hosted
           RENOVATE_ONBOARDING: "false"
-          # Username for GitHub authentication (should match GitHub App name + [bot])
-          RENOVATE_USERNAME: "helm-charts[bot]"
+          # Must match the real identity behind RENOVATE_TOKEN. Renovate uses this
+          # to find its own previously-created Dependency Dashboard issue; a mismatch
+          # here means it never finds it and creates a new one on every run instead
+          # of updating it. RENOVATE_TOKEN currently authenticates as spartan-dou
+          # (not a "helm-charts[bot]" App/machine account), so this must match that.
+          RENOVATE_USERNAME: "spartan-dou"
           # Use GitHub API to create commits (this allows for signed commits from GitHub App)
           RENOVATE_PLATFORM_COMMIT: "true"
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}


### PR DESCRIPTION
## Summary

Every `renovate.yml` run logged `INFO: Issue created` instead of `Issue updated`, and the repo had accumulated **292 open "Dependency Dashboard" issues** (cleanup tracked separately, not part of this diff).

**Root cause:** the actual author of these issues is `spartan-dou` (verified on issue #512), not `helm-charts[bot]`. `RENOVATE_USERNAME` was set to `"helm-charts[bot]"`, which Renovate uses to identify its own previously-created Dependency Dashboard issue. Since that never matches `RENOVATE_TOKEN`'s real identity, Renovate can never find its existing dashboard issue and creates a brand new one on every scheduled run instead of editing it in place.

**Fix:** changed `RENOVATE_USERNAME` to `"spartan-dou"` to match the token's actual identity, so Renovate can find and update its existing dashboard issue going forward.

Note: if a dedicated bot/App identity (`helm-charts[bot]`) is wanted instead of the personal account, `RENOVATE_TOKEN` itself would need to be rotated to that account's token — that's an account-level action outside this repo's config, so it's out of scope here.

## Test plan

- [x] Diagnosed from actual `renovate.yml` job logs (confirmed `Issue created` every run) and the real `user.login` on issue #512.
- [ ] Confirm tomorrow's scheduled `renovate.yml` run (or a manual `workflow_dispatch`) logs `Issue updated` / edits the existing dashboard instead of creating a new one.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_