### PR TITLE
Validate rendered manifests against the Kubernetes schema in CI

### DIFF
--- a/.github/workflows/helm-tests.yml
+++ b/.github/workflows/helm-tests.yml
@@ -30,3 +30,18 @@ jobs:
 
       - name: Run Helm unit tests
         run: helm unittest charts/commons
+
+      - name: Install kubeconform
+        run: |
+          curl -sSL https://github.com/yannh/kubeconform/releases/latest/download/kubeconform-linux-amd64.tar.gz \
+            | tar -xz -C /usr/local/bin kubeconform
+
+      - name: Validate rendered manifests against the Kubernetes schema (default values)
+        run: |
+          helm template test charts/commons \
+            | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.31.0
+
+      - name: Validate rendered manifests against the Kubernetes schema (full test values)
+        run: |
+          helm template test charts/commons -f charts/commons/tests/values/values.yaml \
+            | kubeconform -strict -summary -ignore-missing-schemas -kubernetes-version 1.31.0

--- a/README.md
+++ b/README.md
@@ -381,4 +381,4 @@ helm lint charts/commons
 helm unittest charts/commons
 ```
 
-Le workflow GitHub Actions `helm-tests.yml` exécute les deux commandes ci-dessus sur chaque pull request touchant `charts/**`.
+Le workflow GitHub Actions `helm-tests.yml` exécute ces commandes sur chaque pull request touchant `charts/**`. Il valide aussi le YAML rendu (`helm template`, valeurs par défaut et valeurs de test) contre le schéma Kubernetes officiel via [`kubeconform`](https://github.com/yannh/kubeconform), en ignorant la ressource `Cluster` de CloudNativePG (CRD sans schéma local disponible). Cela attrape des erreurs de structure (champ inconnu, type invalide) que les assertions `helm-unittest` ne couvrent pas forcément.


### PR DESCRIPTION
## Summary

Adds [`kubeconform`](https://github.com/yannh/kubeconform) to `helm-tests.yml`, run against both `helm template` with default values and with the full test fixture, piped straight from Helm's output (kubeconform's documented Helm integration pattern: `helm template . | kubeconform`).

`-ignore-missing-schemas` skips CloudNativePG's `Cluster` CRD (`postgresql.cnpg.io/v1`), which kubeconform has no local schema for, so it doesn't produce a false failure on the one non-core resource this chart renders.

This complements `helm-unittest` rather than replacing it: `helm-unittest` asserts specific values at specific paths, while `kubeconform` validates the rendered YAML's structure against the real Kubernetes API schema — catching unknown fields, wrong types, or invalid enums that a path-based assertion wouldn't think to check for.

## Test plan

- [x] Workflow YAML is valid.
- [x] The invocation matches kubeconform's documented Helm usage.
- [ ] Could not run kubeconform in this environment to verify locally (no network access to install the binary in this sandbox) — should be double-checked on the first real CI run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DGNMrWFCf1yVcKnNNyheJy)_