### PR TITLE
feat(commons): supporte les ResourceClaims DRA au niveau du pod

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -191,6 +191,7 @@ Each entry in the `components` list accepts:
 | `securityContext` | — | Merged with `global.securityContext`. |
 | `nodeSelector` | — | |
 | `hostNetwork` | — | |
+| `resourceClaims[]` | — | DRA resources, at the pod level. Passed through as-is. See [DRA](#dynamic-resource-allocation-dra). |
 | `initContainers[]` | — | `name` (defaults to the component name), `image.repository`, `image.tag` (default `latest`), `securityContext`, `command`, `args`, `env[]`, `volumeMounts[]`. |
 | `containers[]` | — | See below. |
 | `volumes[]` | — | See [`volumes`](#volumes). |
@@ -206,11 +207,46 @@ Each entry in `containers[]`:
 - `volumeMounts[]` (`name`, `mountPath`, optional `subPath`)
 - `additionalsPorts[]` (`name`, `containerPort`, `protocol` default `TCP`, optional `hostPort`) — *(field name exactly as-is in the chart, with the trailing "s")*
 - `livenessProbe` / `readinessProbe` / `startupProbe` / `probe` — see [Probes](#probes)
-- `resources`
+- `resources` (passed through as-is, including `claims` — see [DRA](#dynamic-resource-allocation-dra))
 
 > If `service.ports` is set on the component, its ports are automatically added to the `ports` section of the **first** container in the list only (in addition to its own `additionalsPorts`, if any). Other containers only get their own `additionalsPorts`, if they define any.
 
 A `checksum/<volume-name>` annotation is automatically added to the pod for every chart-generated `configMap` volume (not `useExisting` ones) that has `data`, to trigger a rollout whenever the ConfigMap's content changes.
+
+#### Dynamic Resource Allocation (DRA)
+
+[DRA](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) is GA as of Kubernetes 1.34 (`resource.k8s.io/v1`). For accelerators (GPUs, TPUs…) it replaces the device plugin model: instead of counting a whole resource (`limits: {nvidia.com/gpu: 1}`), the pod references a `ResourceClaim` that **the scheduler allocates before placing the pod**.
+
+The practical consequence: an unavailable resource leaves the pod `Pending` and retried, whereas a device plugin that has not registered yet produced a terminal `UnexpectedAdmissionError` — typically after a node reboot.
+
+Two blocks, at two levels, and both are required:
+
+```yaml
+components:
+  - name: inference
+    deployment:
+      # 1. Pod level: which claims, and what produces them.
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: single-gpu   # or resourceClaimName for an existing claim
+      containers:
+        - name: server
+          image:
+            repository: ollama/ollama
+            tag: latest
+          resources:
+            requests: {cpu: 400m, memory: 4Gi}
+            limits: {cpu: 3000m, memory: 32Gi}
+            # 2. Container level: which of the pod's claims it consumes.
+            claims:
+              - name: gpu
+```
+
+Several containers in the same pod may reference the same claim: that is DRA's sharing model, where the device plugin required a whole resource per container.
+
+The chart only copies both blocks through. The `ResourceClaimTemplate` (or `ResourceClaim`) and the `DeviceClass` it targets must be created alongside, usually by the vendor's driver.
+
+> The expected shape is the Kubernetes 1.31+ one, with `resourceClaimName` / `resourceClaimTemplateName` at the root of the entry. The nested `source` block from earlier versions is deprecated.
 
 #### Environment variables and `commons.getValue`
 

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ Chaque entrée de `components` (liste) accepte :
 | `securityContext` | — | Fusionné avec `global.securityContext`. |
 | `nodeSelector` | — | |
 | `hostNetwork` | — | |
+| `resourceClaims[]` | — | Ressources DRA, au niveau du pod. Passé tel quel. Voir [DRA](#dynamic-resource-allocation-dra). |
 | `initContainers[]` | — | `name` (def. nom du component), `image.repository`, `image.tag` (def. `latest`), `securityContext`, `command`, `args`, `env[]`, `volumeMounts[]`. |
 | `containers[]` | — | Voir ci-dessous. |
 | `volumes[]` | — | Voir [`volumes`](#volumes). |
@@ -206,11 +207,46 @@ Chaque entrée de `containers[]` :
 - `volumeMounts[]` (`name`, `mountPath`, `subPath` optionnel)
 - `additionalsPorts[]` (`name`, `containerPort`, `protocol` def. `TCP`, `hostPort` optionnel) — *(nom de champ tel quel dans la chart, avec le "s")*
 - `livenessProbe` / `readinessProbe` / `startupProbe` / `probe` — voir [Probes](#probes)
-- `resources`
+- `resources` (passé tel quel, y compris `claims` — voir [DRA](#dynamic-resource-allocation-dra))
 
 > Si `service.ports` est défini sur le component, ses ports sont automatiquement ajoutés à la section `ports` du **premier** conteneur de la liste uniquement (en plus de ses éventuels `additionalsPorts`). Les autres conteneurs ne reçoivent que leurs propres `additionalsPorts`, s'ils en définissent.
 
 Une annotation `checksum/<nom-du-volume>` est automatiquement ajoutée au pod pour chaque volume de type `configMap` généré par la chart (pas les `useExisting`) contenant des `data`, afin de déclencher un rollout quand le contenu du ConfigMap change.
+
+#### Dynamic Resource Allocation (DRA)
+
+[DRA](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) est GA depuis Kubernetes 1.34 (`resource.k8s.io/v1`). Pour les accélérateurs (GPU, TPU…), il remplace le modèle des device plugins : au lieu de compter une ressource entière (`limits: {nvidia.com/gpu: 1}`), le pod référence une `ResourceClaim` que **le scheduler alloue avant de placer le pod**.
+
+Conséquence pratique : une ressource indisponible laisse le pod `Pending` et réessayé, là où un device plugin pas encore enregistré produisait un `UnexpectedAdmissionError` définitif — typiquement au redémarrage d'un nœud.
+
+Deux blocs, à deux niveaux, et les deux sont nécessaires :
+
+```yaml
+components:
+  - name: inference
+    deployment:
+      # 1. Au niveau du pod : quelles claims, et qui les produit.
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: single-gpu   # ou resourceClaimName pour une claim existante
+      containers:
+        - name: server
+          image:
+            repository: ollama/ollama
+            tag: latest
+          resources:
+            requests: {cpu: 400m, memory: 4Gi}
+            limits: {cpu: 3000m, memory: 32Gi}
+            # 2. Au niveau du conteneur : quelles claims du pod il consomme.
+            claims:
+              - name: gpu
+```
+
+Plusieurs conteneurs d'un même pod peuvent référencer la même claim : c'est le mode de partage de DRA, là où le device plugin exigeait une ressource entière par conteneur.
+
+La chart ne fait que recopier les deux blocs. La `ResourceClaimTemplate` (ou la `ResourceClaim`) et la `DeviceClass` qu'elle vise sont à créer à côté, généralement par le driver du fournisseur.
+
+> La forme attendue est celle de Kubernetes 1.31+, avec `resourceClaimName` / `resourceClaimTemplateName` à la racine de l'entrée. Le bloc `source` imbriqué des versions antérieures est déprécié.
 
 #### Variables d'environnement et `commons.getValue`
 

--- a/charts/commons/Chart.yaml
+++ b/charts/commons/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: commons
 description: Generic "à la carte" Helm chart to deploy one or several lightweight applications (Deployment/Service/Ingress/CronJob) from a single values file, with optional Redis, PostgreSQL (CloudNativePG), pgAdmin and code-server addons.
 type: application
-version: 0.8.0-beta.1
+version: 0.8.0-beta.2
 keywords:
   - generic
   - library

--- a/charts/commons/templates/deployment.yaml
+++ b/charts/commons/templates/deployment.yaml
@@ -42,6 +42,10 @@ spec:
       {{- with .hostNetwork }}
       hostNetwork: {{ . }}
       {{- end }}
+      {{- with .resourceClaims }}
+      resourceClaims:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .initContainers }}
       initContainers:
         {{- range . }}

--- a/charts/commons/tests/resource_claims_test.yaml
+++ b/charts/commons/tests/resource_claims_test.yaml
@@ -1,0 +1,72 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Dynamic Resource Allocation (`deployment.resourceClaims`)
+values:
+  - ./values/resource-claims-values.yaml
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+tests:
+  - it: Déclare la claim au niveau du pod, produite par un ResourceClaimTemplate
+    documentSelector:
+      path: metadata.name
+      value: test-inference
+    asserts:
+      - equal:
+          path: spec.template.spec.resourceClaims[0].name
+          value: gpu
+      - equal:
+          path: spec.template.spec.resourceClaims[0].resourceClaimTemplateName
+          value: single-gpu
+      # Le bloc `source` imbriqué est déprécié depuis Kubernetes 1.31 : la
+      # fixture utilise la forme à plat, et rien ne doit la ré-imbriquer.
+      - notExists:
+          path: spec.template.spec.resourceClaims[0].source
+
+  - it: Accepte une ResourceClaim existante plutôt qu'un template
+    documentSelector:
+      path: metadata.name
+      value: test-transcode
+    asserts:
+      - equal:
+          path: spec.template.spec.resourceClaims[0].name
+          value: igpu
+      - equal:
+          path: spec.template.spec.resourceClaims[0].resourceClaimName
+          value: igpu-partage
+      - notExists:
+          path: spec.template.spec.resourceClaims[0].resourceClaimTemplateName
+
+  - it: Reporte `resources.claims` sur chaque conteneur qui consomme la claim
+    documentSelector:
+      path: metadata.name
+      value: test-inference
+    asserts:
+      # Deux conteneurs partagent la même claim déclarée une seule fois au
+      # niveau du pod : c'est le mode de partage de DRA, là où le device plugin
+      # exigeait une ressource entière par conteneur.
+      - equal:
+          path: spec.template.spec.containers[0].resources.claims[0].name
+          value: gpu
+      - equal:
+          path: spec.template.spec.containers[1].resources.claims[0].name
+          value: gpu
+      # `resources` reste par ailleurs intact.
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 32Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 400m
+
+  - it: N'émet aucun bloc resourceClaims quand le component n'en déclare pas
+    documentSelector:
+      path: metadata.name
+      value: test-sans-claim
+    asserts:
+      # Un `resourceClaims: null` ou `[]` émis systématiquement casserait la
+      # validation de schéma sur tous les déploiements existants.
+      - notExists:
+          path: spec.template.spec.resourceClaims
+      - notExists:
+          path: spec.template.spec.containers[0].resources.claims

--- a/charts/commons/tests/values/resource-claims-values.yaml
+++ b/charts/commons/tests/values/resource-claims-values.yaml
@@ -1,0 +1,97 @@
+# Fixture dédiée à Dynamic Resource Allocation (DRA).
+#
+# DRA est GA depuis Kubernetes 1.34 (resource.k8s.io/v1) et remplace, pour les
+# accélérateurs, le modèle des device plugins : au lieu de compter une ressource
+# entière (`limits: {nvidia.com/gpu: 1}`), le pod référence une ResourceClaim que
+# le scheduler alloue AVANT de le placer.
+#
+# Côté chart, cela demande deux choses, à deux niveaux différents :
+#
+#   - `deployment.resourceClaims` — au niveau du pod, la déclaration de la claim
+#     et de ce qui la produit (ResourceClaimTemplate ou ResourceClaim existante) ;
+#   - `containers[].resources.claims` — au niveau du conteneur, quelles claims du
+#     pod ce conteneur consomme.
+#
+# Le second passait déjà, `resources` étant recopié tel quel. Le premier est ce
+# que cette fixture couvre.
+#
+# La forme utilisée ici est celle de Kubernetes 1.31+, où les champs
+# `resourceClaimName` et `resourceClaimTemplateName` sont remontés à la racine de
+# l'entrée ; le bloc `source` imbriqué des versions antérieures est déprécié.
+
+components:
+  # Deux conteneurs partageant une même claim produite par un template :
+  # le cas d'un serveur d'inférence et de son interface, sur le même GPU.
+  - name: inference
+    deployment:
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: single-gpu
+      containers:
+        - name: server
+          image:
+            repository: ollama/ollama
+            tag: latest
+          resources:
+            requests:
+              cpu: 400m
+              memory: 4Gi
+            limits:
+              cpu: 3000m
+              memory: 32Gi
+            claims:
+              - name: gpu
+        - name: sidecar
+          image:
+            repository: nginx
+            tag: latest
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+            claims:
+              - name: gpu
+
+  # Une claim déjà existante dans le namespace plutôt qu'un template, et un
+  # conteneur qui n'en consomme aucune : le pod peut déclarer une claim sans que
+  # tous ses conteneurs y touchent.
+  - name: transcode
+    deployment:
+      resourceClaims:
+        - name: igpu
+          resourceClaimName: igpu-partage
+      containers:
+        - name: jellyfin
+          image:
+            repository: jellyfin/jellyfin
+            tag: latest
+          resources:
+            requests:
+              cpu: 400m
+              memory: 2Gi
+            limits:
+              cpu: 2000m
+              memory: 16Gi
+            claims:
+              - name: igpu
+
+  # Aucun `resourceClaims` : le bloc ne doit pas apparaître du tout dans le pod
+  # spec. Un `resourceClaims: null` ou `[]` émis systématiquement ferait échouer
+  # la validation de schéma.
+  - name: sans-claim
+    deployment:
+      containers:
+        - name: app
+          image:
+            repository: nginx
+            tag: latest
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi


### PR DESCRIPTION
## Pourquoi

[DRA](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/) est GA depuis Kubernetes 1.34 (`resource.k8s.io/v1`). Pour les accélérateurs, il remplace le modèle des device plugins : au lieu de compter une ressource entière (`limits: {nvidia.com/gpu: 1}`), le pod référence une `ResourceClaim` que **le scheduler alloue avant de placer le pod**.

L'intérêt concret : une ressource indisponible laisse le pod `Pending` et réessayé, là où un device plugin pas encore enregistré produisait un `UnexpectedAdmissionError` **définitif** — typiquement au redémarrage d'un nœud ([kubernetes#125579](https://github.com/kubernetes/kubernetes/issues/125579)).

## Le changement est plus petit qu'attendu

Consommer DRA demande deux blocs, à deux niveaux :

| Niveau | Champ | État avant cette PR |
|---|---|---|
| Conteneur | `resources.claims` | ✅ **passait déjà** |
| Pod | `spec.resourceClaims` | ❌ absent |

Le premier fonctionnait sans le savoir : `templates/deployment.yaml` fait `{{- toYaml . | nindent 12 }}` sur `.resources`, et `toYaml` ne filtre aucune clé. Seul le niveau pod manquait.

D'où un diff de **quatre lignes** dans le template, au même endroit et selon le même motif que `nodeSelector` et `hostNetwork` :

```gotemplate
      {{- with .resourceClaims }}
      resourceClaims:
        {{- toYaml . | nindent 8 }}
      {{- end }}
```

Recopie pure, aucune logique. La `ResourceClaimTemplate` et la `DeviceClass` visées restent à créer à côté, généralement par le driver du fournisseur.

## Usage

```yaml
components:
  - name: inference
    deployment:
      resourceClaims:
        - name: gpu
          resourceClaimTemplateName: single-gpu   # ou resourceClaimName
      containers:
        - name: server
          image: {repository: ollama/ollama, tag: latest}
          resources:
            requests: {cpu: 400m, memory: 4Gi}
            limits: {cpu: 3000m, memory: 32Gi}
            claims:
              - name: gpu
```

Plusieurs conteneurs d'un même pod peuvent référencer la même claim : c'est le mode de partage de DRA, là où le device plugin exigeait une ressource entière par conteneur.

La forme retenue est celle de **Kubernetes 1.31+**, avec `resourceClaimName` / `resourceClaimTemplateName` à la racine de l'entrée. Le bloc `source` imbriqué des versions antérieures est déprécié, et un test vérifie qu'on ne le réintroduit pas.

## Tests

Nouvelle suite `tests/resource_claims_test.yaml` + fixture dédiée, sur le modèle de `external_secrets_test.yaml`. Quatre cas :

1. claim produite par un `ResourceClaimTemplate` ;
2. claim existante référencée par nom (`resourceClaimName`) ;
3. `resources.claims` reporté sur deux conteneurs partageant la même claim, sans abîmer `requests`/`limits` ;
4. **aucun bloc émis quand le component n'en déclare pas** — c'est le cas qui compte : un `resourceClaims: null` systématique casserait la validation de schéma sur tous les déploiements existants.

Le job `helm-tests` valide déjà le rendu contre le schéma Kubernetes avec `kubeconform -kubernetes-version 1.31.0` ; `resourceClaims` et `resources.claims` y sont tous deux présents.

## Version

`0.8.0-beta.1` → **`0.8.0-beta.2`**. `chart-releaser` tourne avec `CR_SKIP_EXISTING: true` : sans montée de version, rien n'est publié et le changement resterait invisible aux consommateurs.

## Vérification — à lire

**Je n'ai pas pu exécuter `helm lint`, `helm unittest` ni `helm template` localement** : `get.helm.sh` est bloqué par la politique réseau de l'environnement de développement, et Helm ne publie pas ses binaires en assets GitHub. Ce qui a été vérifié à la place :

- les deux fichiers YAML ajoutés parsent, et la fixture produit bien la structure attendue (contrôlé en Python) ;
- `notExists` est une assertion valide — présente dans le schéma helm-unittest **et** déjà utilisée dans `tests/` de ce dépôt ;
- le repli de `commons.fullname` sur le nom du component (et non `deployment.name`) est confirmé dans `_commons.tpl` et par les sélecteurs de `external_secrets_test.yaml` — les documents visés sont donc bien `test-inference`, `test-transcode`, `test-sans-claim` ;
- les fins de ligne CRLF de `deployment.yaml` et `Chart.yaml` sont préservées ; les deux fichiers ajoutés sont en LF, comme les `external_secrets_*` ajoutés en dernier.

Le job `helm-tests` de la CI est donc la première exécution réelle.

## Contexte

Cette PR débloque la migration DRA côté `spartan-dou/cluster-config` (PR #649), où neuf composants GPU passent par cette chart.

---
_Generated by [Claude Code](https://claude.ai/code/session_019p8tBJrQWKDWVVVxq3xDRF)_