### PR TITLE
commons: génère l'IngressRoute Authentik outpost par hôte (0.8.0-beta.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Ce changement s'applique **aussi au mode historique** (mot de passe en clair dan
 | `global.rbac.rules` | — | Liste de `PolicyRule` (format RBAC Kubernetes standard) pour le `ClusterRole`. |
 | `global.var` | `{}` | Espace de clé/valeur libre, accessible depuis n'importe quelle `env[].value` via `__global__<clé>` (voir [`commons.getValue`](#variables-denvironnement-et-commonsgetvalue)). |
 | `global.ingress.className` | `traefik` | `ingressClassName` par défaut pour tout `ingress` (component ou addon, y compris `addons.pgadmin.ingress`) qui ne définit pas explicitement son propre `className`. |
+| `global.ingress.authentikOutpost.*` | Voir [`authentikOutpost`](#authentikoutpost) | Valeurs par défaut (`priority`, `entryPoints`, `serviceName`, `serviceNamespace`, `servicePort`) pour tous les `hosts[].authentikOutpost` du chart, surchargeables par hôte. |
 
 ### Un `component`
 
@@ -315,7 +316,45 @@ Chaque entrée de `deployment.volumes[]` (et `cronjobs[].initContainers[]/contai
 | `hosts[].paths[].pathType` | `Prefix` | |
 | `hosts[].paths[].name` | Service du component | Nom du Service backend ; par défaut celui généré pour le component courant. |
 | `hosts[].paths[].port` | `80` | Port du Service backend : un entier est rendu comme `port.number`, une chaîne comme `port.name` (port nommé). |
+| `hosts[].authentikOutpost` | — | Voir [`authentikOutpost`](#authentikoutpost). |
 | `tls[]` | — | Passé tel quel (`toYaml`), format standard `spec.tls` d'un Ingress. |
+
+##### `authentikOutpost`
+
+Génère une `IngressRoute` Traefik (`traefik.io/v1alpha1`) dédiée, qui route
+`/outpost.goauthentik.io/` sur cet hôte vers l'outpost Authentik du cluster —
+nécessaire pour le mode forward auth **single application** (un provider
+par hôte, une policy de groupe par hôte). Opt-in par hôte, pas par ingress :
+un `ingress` qui sert plusieurs `hosts[]` peut n'activer ceci que sur
+certains.
+
+| Clé | Défaut | Description |
+|---|---|---|
+| `enabled` | `false` | |
+| `name` | Premier label DNS de `host` (ex. `app` pour `app.example.com`) | Suffixe du nom de l'objet `IngressRoute` généré ; à préciser si deux hôtes du même component partagent ce label (rare). |
+| `priority` | `global.ingress.authentikOutpost.priority` (`15`) | |
+| `entryPoints` | `global.ingress.authentikOutpost.entryPoints` (`["websecure"]`) | |
+| `serviceName` | `global.ingress.authentikOutpost.serviceName` (`traefik-outpost`) | |
+| `serviceNamespace` | `global.ingress.authentikOutpost.serviceNamespace` (`authentik`) | |
+| `servicePort` | `global.ingress.authentikOutpost.servicePort` (`9000`) | |
+
+Le `secretName` TLS de l'`IngressRoute` générée est déduit automatiquement
+du bloc `tls[]` de l'`ingress` dont fait partie l'hôte (celui dont
+`tls[].hosts` contient `host`) — rien à répéter.
+
+```yaml
+components:
+  - name: app
+    ingress:
+      enabled: true
+      hosts:
+        - host: app.example.com
+          authentikOutpost:
+            enabled: true
+      tls:
+        - hosts: [app.example.com]
+          secretName: app-tls
+```
 
 #### `secrets`
 

--- a/charts/commons/Chart.yaml
+++ b/charts/commons/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: commons
 description: Generic "à la carte" Helm chart to deploy one or several lightweight applications (Deployment/Service/Ingress/CronJob) from a single values file, with optional Redis, PostgreSQL (CloudNativePG), pgAdmin and code-server addons.
 type: application
-version: 0.8.0-beta.1
+version: 0.8.0-beta.2
 keywords:
   - generic
   - library

--- a/charts/commons/templates/ingressroute-authentik-outpost.yaml
+++ b/charts/commons/templates/ingressroute-authentik-outpost.yaml
@@ -1,0 +1,62 @@
+{{/*
+  Une IngressRoute Traefik par hôte optant pour `authentikOutpost.enabled`,
+  routant /outpost.goauthentik.io/ vers l'outpost Authentik du cluster —
+  requis pour le mode forward auth "single application" (un provider par
+  hôte, une policy de groupe par hôte), voir la doc du projet consommateur.
+
+  Opt-in par hôte, pas par ingress : un même Ingress peut servir plusieurs
+  hôtes dont un seul (ou aucun) a besoin de cette route.
+*/}}
+{{- $components := include "commons.withAddons" . | fromYamlArray }}
+{{- $globalCfg := $.Values.global.ingress.authentikOutpost | default dict }}
+{{- $defaultServiceName := default "traefik-outpost" $globalCfg.serviceName }}
+{{- $defaultServiceNamespace := default "authentik" $globalCfg.serviceNamespace }}
+{{- $defaultServicePort := default 9000 $globalCfg.servicePort }}
+{{- $defaultPriority := default 15 $globalCfg.priority }}
+{{- $defaultEntryPoints := default (list "websecure") $globalCfg.entryPoints }}
+{{- range $components }}
+{{- $component := . }}
+{{- with $component.ingress }}
+{{- $ingress := . }}
+{{- if $ingress.enabled }}
+{{- range $ingress.hosts }}
+{{- $host := . }}
+{{- with $host.authentikOutpost }}
+{{- $outpost := . }}
+{{- if $outpost.enabled }}
+{{- $secretName := "" }}
+{{- range $ingress.tls }}
+  {{- if has $host.host (.hosts | default list) }}
+    {{- $secretName = .secretName }}
+  {{- end }}
+{{- end }}
+{{- $suffix := default (splitList "." $host.host | first) $outpost.name }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ include "commons.fullname" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release "name" (printf "%s-outpost" $suffix) "component" $component) }}
+  labels:
+    {{- include "commons.labels" (dict "Chart" $.Chart "Values" $.Values "Release" $.Release "name" $ingress.name "component" $component) | nindent 4 }}
+spec:
+  entryPoints:
+    {{- toYaml (default $defaultEntryPoints $outpost.entryPoints) | nindent 4 }}
+  routes:
+    - kind: Rule
+      match: Host(`{{ $host.host }}`) && PathPrefix(`/outpost.goauthentik.io/`)
+      priority: {{ default $defaultPriority $outpost.priority }}
+      services:
+        - kind: Service
+          name: {{ default $defaultServiceName $outpost.serviceName }}
+          namespace: {{ default $defaultServiceNamespace $outpost.serviceNamespace }}
+          port: {{ default $defaultServicePort $outpost.servicePort }}
+  {{- if $secretName }}
+  tls:
+    secretName: {{ $secretName }}
+  {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/commons/tests/ingressroute_authentik_outpost_test.yaml
+++ b/charts/commons/tests/ingressroute_authentik_outpost_test.yaml
@@ -1,0 +1,270 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/helm-unittest/helm-unittest/main/schema/helm-testsuite.json
+suite: Tests de templates/ingressroute-authentik-outpost.yaml
+templates:
+  - templates/ingressroute-authentik-outpost.yaml
+release:
+  name: test
+tests:
+  - it: ne génère rien quand aucun hôte n'active authentikOutpost
+    values:
+      - ./values/values.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: génère une IngressRoute pour l'hôte qui active authentikOutpost, avec les valeurs par défaut
+    set:
+      global:
+        timezone: Europe/Paris
+        pvc:
+          storage:
+            size: 1Gi
+        rbac:
+          enabled: false
+        ingress:
+          className: traefik
+      components:
+        - name: app
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          service:
+            ports:
+              - name: http
+                port: 80
+          ingress:
+            enabled: true
+            hosts:
+              - host: home.example.com
+                authentikOutpost:
+                  enabled: true
+                paths:
+                  - path: /
+            tls:
+              - hosts: [home.example.com]
+                secretName: home-tls
+      addons:
+        vscode:
+          enabled: false
+        redis:
+          enabled: false
+        pgadmin:
+          enabled: false
+        postgres:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: test-app-home-outpost
+      - equal:
+          path: spec.entryPoints
+          value: [websecure]
+      - equal:
+          path: spec.routes[0].match
+          value: "Host(`home.example.com`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      - equal:
+          path: spec.routes[0].priority
+          value: 15
+      - equal:
+          path: spec.routes[0].services[0].name
+          value: traefik-outpost
+      - equal:
+          path: spec.routes[0].services[0].namespace
+          value: authentik
+      - equal:
+          path: spec.routes[0].services[0].port
+          value: 9000
+      - equal:
+          path: spec.tls.secretName
+          value: home-tls
+
+  - it: n'active la route que sur l'hôte opt-in quand un ingress sert plusieurs hôtes (cas Homepage)
+    set:
+      global:
+        timezone: Europe/Paris
+        pvc:
+          storage:
+            size: 1Gi
+        rbac:
+          enabled: false
+        ingress:
+          className: traefik
+      components:
+        - name: app
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          service:
+            ports:
+              - name: http
+                port: 80
+          ingress:
+            enabled: true
+            hosts:
+              - host: home.example.com
+                authentikOutpost:
+                  enabled: true
+                paths:
+                  - path: /
+              - host: example.com
+                paths:
+                  - path: /
+            tls:
+              - hosts: [home.example.com]
+                secretName: home-tls
+              - hosts: [example.com]
+                secretName: root-tls
+      addons:
+        vscode:
+          enabled: false
+        redis:
+          enabled: false
+        pgadmin:
+          enabled: false
+        postgres:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: spec.routes[0].match
+          value: "Host(`home.example.com`) && PathPrefix(`/outpost.goauthentik.io/`)"
+
+  - it: applique le défaut global (serviceNamespace, priority) à l'hôte qui ne le surcharge pas
+    set:
+      global:
+        timezone: Europe/Paris
+        pvc:
+          storage:
+            size: 1Gi
+        rbac:
+          enabled: false
+        ingress:
+          className: traefik
+          authentikOutpost:
+            priority: 20
+            serviceNamespace: authentik-custom
+      components:
+        - name: app
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          service:
+            ports:
+              - name: http
+                port: 80
+          ingress:
+            enabled: true
+            hosts:
+              - host: home.example.com
+                authentikOutpost:
+                  enabled: true
+                paths:
+                  - path: /
+              - host: example.com
+                authentikOutpost:
+                  enabled: true
+                  name: root
+                  priority: 30
+                paths:
+                  - path: /
+            tls:
+              - hosts: [home.example.com]
+                secretName: home-tls
+              - hosts: [example.com]
+                secretName: root-tls
+      addons:
+        vscode:
+          enabled: false
+        redis:
+          enabled: false
+        pgadmin:
+          enabled: false
+        postgres:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: test-app-home-outpost
+    asserts:
+      - equal:
+          path: spec.routes[0].priority
+          value: 20
+      - equal:
+          path: spec.routes[0].services[0].namespace
+          value: authentik-custom
+
+  - it: la surcharge par hôte (name, priority) prévaut sur le défaut global
+    set:
+      global:
+        timezone: Europe/Paris
+        pvc:
+          storage:
+            size: 1Gi
+        rbac:
+          enabled: false
+        ingress:
+          className: traefik
+          authentikOutpost:
+            priority: 20
+            serviceNamespace: authentik-custom
+      components:
+        - name: app
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          service:
+            ports:
+              - name: http
+                port: 80
+          ingress:
+            enabled: true
+            hosts:
+              - host: home.example.com
+                authentikOutpost:
+                  enabled: true
+                paths:
+                  - path: /
+              - host: example.com
+                authentikOutpost:
+                  enabled: true
+                  name: root
+                  priority: 30
+                paths:
+                  - path: /
+            tls:
+              - hosts: [home.example.com]
+                secretName: home-tls
+              - hosts: [example.com]
+                secretName: root-tls
+      addons:
+        vscode:
+          enabled: false
+        redis:
+          enabled: false
+        pgadmin:
+          enabled: false
+        postgres:
+          enabled: false
+    documentSelector:
+      path: metadata.name
+      value: test-app-root-outpost
+    asserts:
+      - equal:
+          path: spec.routes[0].match
+          value: "Host(`example.com`) && PathPrefix(`/outpost.goauthentik.io/`)"
+      - equal:
+          path: spec.routes[0].priority
+          value: 30
+      - equal:
+          path: spec.routes[0].services[0].namespace
+          value: authentik-custom


### PR DESCRIPTION
Suite du chantier de migration single-application dans `cluster-config` : chaque hôte forward-auth migré nécessite une `IngressRoute` Traefik dédiée écrite à la main pour router `/outpost.goauthentik.io/` vers l'outpost Authentik. Cette PR le fait générer par le chart.

## Le nouveau champ

Opt-in **par hôte**, pas par ingress — un même `Ingress` peut servir plusieurs hôtes dont un seul a besoin de la route (cas réel : Homepage sert `home.dou-s-home.fr` et `dou-s-home.fr` sur un seul `Ingress`) :

```yaml
components:
  - name: app
    ingress:
      hosts:
        - host: app.example.com
          authentikOutpost:
            enabled: true
```

Le `secretName` TLS est déduit automatiquement du bloc `tls[]` correspondant à l'hôte — rien à répéter. Défauts (service/namespace/port de l'outpost, priorité, entryPoints) configurables globalement via `global.ingress.authentikOutpost.*`, surchargeables par hôte.

Purement additif : `values.schema.json` ne validait déjà pas le contenu du bloc `ingress` en détail, donc pas de changement de schéma nécessaire ; aucun effet sur les components existants qui n'activent pas le champ.

## Vérifications

- `helm unittest charts/commons` : 59 tests passés (54 existants + 5 nouveaux couvrant l'absence de route par défaut, les valeurs par défaut, le cas multi-hôtes type Homepage, et les surcharges par hôte vs. globales)
- `helm template` manuel sur les cas Homepage (deux hôtes, un seul opt-in) et surcharges, sortie vérifiée ligne à ligne

## Suite

Une fois publiée, `cluster-config` migrera les apps qui utilisent réellement ce chart vers `authentikOutpost` et supprimera les `IngressRoute` écrites à la main correspondantes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVUjXU78J4VuDANdtu5e8w)_