### PR TITLE
commons 0.8.1 : rendre `postgres.monitoring` trouvable

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -401,7 +401,7 @@ Creates a dedicated CloudNativePG `Cluster` + a `kubernetes.io/basic-auth` Secre
 | `cluster.database` | `app` | |
 | `postInitTemplateSQL[]` / `postInitSQL[]` / `postInitApplicationSQL[]` | — | Run at CloudNativePG bootstrap. |
 | `backup.destinationPath`, `backup.endpointURL` | — | `barmanObjectStore` backup (S3). Expects a `<name>-backup-secret` Secret with the `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY` keys. |
-| `monitoring` | `false` | `enablePodMonitor`. |
+| `monitoring` | `false` | Sets `spec.monitoring.enablePodMonitor` on the `Cluster`. CloudNativePG then creates the `PodMonitor` exposing `/metrics` (port 9187) to Prometheus — the instance manager serves those metrics either way, without this option nobody comes to collect them. Set independently on each `postgres`: enabling it on `addons.postgres` does not enable it on the databases embedded in components. |
 
 ### RBAC
 
@@ -467,6 +467,7 @@ If `password` is set, a `<release>-redis-auth` Secret is generated, Redis starts
 | `image.tag` | `18` |
 | `cluster.username` / `cluster.password` | `changeme` / `changeme` |
 | `cluster.database` | `app` |
+| `monitoring` | `false` — see the `monitoring` row of [`postgres`](#postgres-embedded-database-on-a-component) |
 
 ### Resource naming
 

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Crée un `Cluster` CloudNativePG dédié + un Secret `kubernetes.io/basic-auth`,
 | `cluster.database` | `app` | |
 | `postInitTemplateSQL[]` / `postInitSQL[]` / `postInitApplicationSQL[]` | — | Exécutés au bootstrap CloudNativePG. |
 | `backup.destinationPath`, `backup.endpointURL` | — | Sauvegarde `barmanObjectStore` (S3). Attend un Secret `<name>-backup-secret` avec les clés `ACCESS_KEY_ID` / `SECRET_ACCESS_KEY`. |
-| `monitoring` | `false` | `enablePodMonitor`. |
+| `monitoring` | `false` | Pose `spec.monitoring.enablePodMonitor` sur le `Cluster`. CloudNativePG crée alors le `PodMonitor` qui expose `/metrics` (port 9187) à Prometheus — l'instance manager sert ces métriques dans tous les cas, sans cette option personne ne vient les chercher. Se règle indépendamment sur chaque `postgres` : l'activer sur `addons.postgres` ne l'active pas sur les bases embarquées dans les components. |
 
 ### RBAC
 
@@ -506,6 +506,7 @@ Cluster CloudNativePG **partagé**, consommable par tous les components via `__a
 | `image.tag` | `18` |
 | `cluster.username` / `cluster.password` | `changeme` / `changeme` |
 | `cluster.database` | `app` |
+| `monitoring` | `false` — voir la ligne `monitoring` de [`postgres`](#postgres-base-embarquée-dans-un-component) |
 
 ### Nommage des ressources
 

--- a/charts/commons/CHANGELOG.md
+++ b/charts/commons/CHANGELOG.md
@@ -10,6 +10,35 @@ paquet publié — d'où le fait qu'il ne soit pas dans `.helmignore`.
 `chart-releaser` reprend le fichier entier, pas la section de la version : une
 release rappelle donc aussi l'historique des précédentes.
 
+## 0.8.1
+
+Aucun changement de rendu à values identiques. La 0.8.1 rend utilisable une
+option qui existait déjà mais que rien ne permettait de trouver.
+
+### `postgres.monitoring` devient une option de premier plan
+
+`postgres.monitoring` pose `spec.monitoring.enablePodMonitor` sur le `Cluster`
+CloudNativePG, donc décide si les métriques Postgres (port 9187, servies de
+toute façon par l'instance manager) sont collectées par Prometheus.
+
+Le template la lisait depuis toujours, et le tableau `postgres` du README la
+mentionnait en trois mots. Mais elle était absente de `values.yaml`, absente de
+`values.schema.json` et couverte par aucun test : en pratique, elle ne se
+découvrait qu'en lisant `templates/cnpg/cluster.yaml`. Une base pouvait rester
+non scrapée sans que rien ne le signale, et l'option pouvait disparaître d'une
+version à l'autre sans faire échouer un seul test.
+
+- `values.yaml` : `addons.postgres.monitoring: false`, commenté.
+- `values.schema.json` : `monitoring` typé `boolean`. **Seul changement de
+  comportement** : `monitoring` écrit sous une autre forme est maintenant
+  refusé avant le rendu (`got object, want boolean`) au lieu d'être injecté
+  tel quel dans un champ booléen du CRD.
+- Tests : défaut à `false`, activation sur `addons.postgres`, activation sur un
+  `postgres` de component, et indépendance des deux (activer l'addon n'active
+  pas les components).
+- README (fr/en) : la ligne du tableau `postgres` dit ce que fait l'option, et
+  le tableau `addons.postgres` — d'où elle manquait — la liste aussi.
+
 ## 0.8.0
 
 Première version stable depuis la **0.7.16**. Les préversions `0.8.0-beta.1` et

--- a/charts/commons/Chart.yaml
+++ b/charts/commons/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: commons
 description: Generic "à la carte" Helm chart to deploy one or several lightweight applications (Deployment/Service/Ingress/CronJob) from a single values file, with optional Redis, PostgreSQL (CloudNativePG), pgAdmin and code-server addons.
 type: application
-version: 0.8.0
+version: 0.8.1
 keywords:
   - generic
   - library

--- a/charts/commons/tests/cnpg_test.yaml
+++ b/charts/commons/tests/cnpg_test.yaml
@@ -103,3 +103,83 @@ tests:
       - equal:
           path: spec.bootstrap.initdb.owner
           value: user-b
+
+  # --- PodMonitor (spec.monitoring.enablePodMonitor) ---
+  #
+  # `postgres.monitoring` était lu par le template mais absent de values.yaml,
+  # de values.schema.json et de ces tests : la seule façon de le découvrir
+  # était de lire cluster.yaml. Il pouvait donc disparaître sans qu'aucun test
+  # ne bronche, et une base cesse d'être scrapée sans erreur nulle part.
+  - it: Ne crée pas de PodMonitor par défaut
+    templates:
+      - templates/cnpg/cluster.yaml
+    documentSelector:
+      path: metadata.name
+      value: test-postgres
+    asserts:
+      - equal:
+          path: spec.monitoring.enablePodMonitor
+          value: false
+
+  - it: Active le PodMonitor sur l'addon postgres
+    templates:
+      - templates/cnpg/cluster.yaml
+    set:
+      addons.postgres.monitoring: true
+    documentSelector:
+      path: metadata.name
+      value: test-postgres
+    asserts:
+      - equal:
+          path: spec.monitoring.enablePodMonitor
+          value: true
+
+  - it: Active le PodMonitor sur un postgres embarqué dans un component
+    templates:
+      - templates/cnpg/cluster.yaml
+    set:
+      components:
+        - name: app-a
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          postgres:
+            enabled: true
+            monitoring: true
+            cluster:
+              username: user-a
+              password: pass-a
+    documentSelector:
+      path: metadata.name
+      value: test-app-a-postgres
+    asserts:
+      - equal:
+          path: spec.monitoring.enablePodMonitor
+          value: true
+
+  - it: N'active pas le PodMonitor d'un component quand seul l'addon l'active
+    templates:
+      - templates/cnpg/cluster.yaml
+    set:
+      addons.postgres.monitoring: true
+      components:
+        - name: app-a
+          deployment:
+            containers:
+              - image:
+                  repository: nginx
+                  tag: latest
+          postgres:
+            enabled: true
+            cluster:
+              username: user-a
+              password: pass-a
+    documentSelector:
+      path: metadata.name
+      value: test-app-a-postgres
+    asserts:
+      - equal:
+          path: spec.monitoring.enablePodMonitor
+          value: false

--- a/charts/commons/values.schema.json
+++ b/charts/commons/values.schema.json
@@ -315,6 +315,10 @@
                   "minLength": 1
                 }
               }
+            },
+            "monitoring": {
+              "description": "Crée le PodMonitor du Cluster CloudNativePG (spec.monitoring.enablePodMonitor).",
+              "type": "boolean"
             }
           },
           "if": {

--- a/charts/commons/values.yaml
+++ b/charts/commons/values.yaml
@@ -104,3 +104,12 @@ addons:
       # ne génère alors aucun Secret et pointe sur celui du namespace.
       password: changeme
       # database: app
+    # Pose `spec.monitoring.enablePodMonitor` sur le Cluster : CloudNativePG
+    # crée alors le PodMonitor qui expose /metrics (port 9187) à Prometheus.
+    # L'instance manager sert ces métriques dans tous les cas — sans cette
+    # option, personne ne vient les chercher.
+    #
+    # La clé était lue par templates/cnpg/cluster.yaml depuis toujours, mais
+    # elle n'apparaissait ni ici ni dans values.schema.json : elle ne se
+    # découvrait qu'en lisant le template.
+    monitoring: false


### PR DESCRIPTION
## Pourquoi

`postgres.monitoring` pose `spec.monitoring.enablePodMonitor` sur le `Cluster` CloudNativePG, donc décide si les métriques Postgres (port 9187, servies de toute façon par l'instance manager) sont collectées par Prometheus.

**L'option existait déjà** — `templates/cnpg/cluster.yaml` la lit depuis longtemps, et le tableau `postgres` du README la mentionnait en trois mots (`` `enablePodMonitor`. ``). Mais elle était absente de `values.yaml`, absente de `values.schema.json`, absente du tableau `addons.postgres`, et couverte par aucun test. En pratique elle ne se découvrait qu'en ouvrant le template.

Ce n'est pas théorique : en auditant le cluster qui consomme ce chart, j'ai conclu à tort que l'option n'existait pas, après avoir lu `values.yaml` sans ouvrir le template. Les neuf bases du cluster étaient toutes à `false` sans que personne ne l'ait décidé, et le dashboard « CloudNativePG » s'affichait vide.

Deux angles morts, donc :

- une base non scrapée ne signale rien — le dashboard s'affiche, il est simplement vide ;
- l'option pouvait disparaître d'une version à l'autre sans faire échouer un seul test.

## Ce que change cette PR

Aucun changement de rendu à values identiques. `templates/` n'est pas touché — les consommateurs déjà sur `0.8.0` peuvent utiliser l'option sans monter de version.

- **`values.yaml`** — `addons.postgres.monitoring: false`, avec le commentaire qui explique ce que ça déclenche.
- **`values.schema.json`** — `monitoring` typée `boolean`. **Seul changement de comportement** : une autre forme est refusée avant le rendu au lieu d'être injectée telle quelle dans un champ booléen du CRD.
  ```
  at '/addons/postgres/monitoring': got object, want boolean
  ```
- **Tests** — 4 cas : défaut à `false`, activation sur `addons.postgres`, activation sur un `postgres` de component, et **indépendance des deux** (activer l'addon n'active pas les components) — comportement réel que rien ne verrouillait.
- **README fr/en** — la ligne du tableau `postgres` dit ce que fait l'option et sur quoi elle ne déborde pas ; le tableau `addons.postgres`, d'où elle manquait entièrement, la liste aussi.
- **`Chart.yaml` / `CHANGELOG.md`** — `0.8.1`.

## Vérifications

Pipeline de `helm-tests.yml` reproduit intégralement en local :

| Étape | Résultat |
|---|---|
| `helm lint charts/commons` | 0 chart failed |
| `helm unittest charts/commons` | **67 tests** (63 avant) |
| `kubeconform -strict` (values par défaut) | 0 invalid |
| `kubeconform -strict` (`tests/values/values.yaml`) | 25 valid, 0 invalid |

Le refus de schéma a été vérifié en écrivant réellement `monitoring: {enabled: true}`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CdLE3nfD3tzdW1NVHkBzhB)_